### PR TITLE
Preserve case for ErrorMetadata structs.

### DIFF
--- a/models/validators/AcceptedValidator.cfc
+++ b/models/validators/AcceptedValidator.cfc
@@ -55,7 +55,7 @@ component accessors="true" singleton {
 			rejectedValue  : ( isSimpleValue( arguments.targetValue ) ? arguments.targetValue : "" ),
 			validationData : arguments.validationData
 		};
-		var error = validationResult.newError( argumentCollection = args ).setErrorMetadata( { max : arguments.validationData } );
+		var error = validationResult.newError( argumentCollection = args ).setErrorMetadata( { 'max' : arguments.validationData } );
 		validationResult.addError( error );
 		return false;
 	}

--- a/models/validators/AlphaValidator.cfc
+++ b/models/validators/AlphaValidator.cfc
@@ -50,7 +50,7 @@ component accessors="true" singleton {
 			rejectedValue  : ( isSimpleValue( arguments.targetValue ) ? arguments.targetValue : "" ),
 			validationData : arguments.validationData
 		};
-		var error = validationResult.newError( argumentCollection = args ).setErrorMetadata( { max : arguments.validationData } );
+		var error = validationResult.newError( argumentCollection = args ).setErrorMetadata( { 'max' : arguments.validationData } );
 		validationResult.addError( error );
 		return false;
 	}

--- a/models/validators/DiscreteValidator.cfc
+++ b/models/validators/DiscreteValidator.cfc
@@ -107,8 +107,8 @@ component accessors="true" singleton {
 			var error = validationResult
 				.newError( argumentCollection = args )
 				.setErrorMetadata( {
-					operation      : operation,
-					operationValue : operationValue
+					'operation'      : operation,
+					'operationValue' : operationValue
 				} );
 			validationResult.addError( error );
 		}

--- a/models/validators/MaxValidator.cfc
+++ b/models/validators/MaxValidator.cfc
@@ -50,7 +50,7 @@ component accessors="true" singleton {
 			rejectedValue  : ( isSimpleValue( arguments.targetValue ) ? arguments.targetValue : "" ),
 			validationData : arguments.validationData
 		};
-		var error = validationResult.newError( argumentCollection = args ).setErrorMetadata( { max : arguments.validationData } );
+		var error = validationResult.newError( argumentCollection = args ).setErrorMetadata( { 'max' : arguments.validationData } );
 		validationResult.addError( error );
 		return false;
 	}

--- a/models/validators/MinValidator.cfc
+++ b/models/validators/MinValidator.cfc
@@ -50,7 +50,7 @@ component accessors="true" singleton {
 			rejectedValue  : ( isSimpleValue( arguments.targetValue ) ? arguments.targetValue : "" ),
 			validationData : arguments.validationData
 		};
-		var error = validationResult.newError( argumentCollection = args ).setErrorMetadata( { min : arguments.validationData } );
+		var error = validationResult.newError( argumentCollection = args ).setErrorMetadata( { 'min' : arguments.validationData } );
 		validationResult.addError( error );
 		return false;
 	}

--- a/models/validators/RangeValidator.cfc
+++ b/models/validators/RangeValidator.cfc
@@ -73,9 +73,9 @@ component accessors="true" singleton {
 		var error = validationResult
 			.newError( argumentCollection = args )
 			.setErrorMetadata( {
-				range : arguments.validationData,
-				min   : min,
-				max   : max
+				'range' : arguments.validationData,
+				'min'   : min,
+				'max'   : max
 			} );
 		validationResult.addError( error );
 		return false;

--- a/models/validators/RegexValidator.cfc
+++ b/models/validators/RegexValidator.cfc
@@ -56,7 +56,7 @@ component accessors="true" singleton {
 			rejectedValue  : ( isSimpleValue( arguments.targetValue ) ? arguments.targetValue : "" ),
 			validationData : arguments.validationData
 		};
-		var error = validationResult.newError( argumentCollection = args ).setErrorMetadata( { regex : arguments.validationData } );
+		var error = validationResult.newError( argumentCollection = args ).setErrorMetadata( { 'regex' : arguments.validationData } );
 		validationResult.addError( error );
 		return false;
 	}

--- a/models/validators/SameAsNoCaseValidator.cfc
+++ b/models/validators/SameAsNoCaseValidator.cfc
@@ -61,7 +61,7 @@ component accessors="true" singleton {
 			rejectedValue  : ( isSimpleValue( arguments.targetValue ) ? arguments.targetValue : "" ),
 			validationData : arguments.validationData
 		};
-		var error = validationResult.newError( argumentCollection = args ).setErrorMetadata( { sameas : arguments.validationData } );
+		var error = validationResult.newError( argumentCollection = args ).setErrorMetadata( { 'sameas' : arguments.validationData } );
 		validationResult.addError( error );
 		return false;
 	}

--- a/models/validators/SameAsValidator.cfc
+++ b/models/validators/SameAsValidator.cfc
@@ -55,7 +55,7 @@ component accessors="true" singleton {
 			rejectedValue  : ( isSimpleValue( arguments.targetValue ) ? arguments.targetValue : "" ),
 			validationData : arguments.validationData
 		};
-		var error = validationResult.newError( argumentCollection = args ).setErrorMetadata( { sameas : arguments.validationData } );
+		var error = validationResult.newError( argumentCollection = args ).setErrorMetadata( { 'sameas' : arguments.validationData } );
 		validationResult.addError( error );
 		return false;
 	}

--- a/models/validators/SizeValidator.cfc
+++ b/models/validators/SizeValidator.cfc
@@ -92,6 +92,7 @@ component accessors="true" singleton {
 				return true;
 			}
 		}
+
 		var args = {
 			message        : "The '#arguments.field#' value is not in the required size range (#arguments.validationData#)",
 			field          : arguments.field,
@@ -99,12 +100,13 @@ component accessors="true" singleton {
 			rejectedValue  : ( isSimpleValue( arguments.targetValue ) ? arguments.targetValue : "" ),
 			validationData : arguments.validationData
 		};
+
 		var error = validationResult
 			.newError( argumentCollection = args )
 			.setErrorMetadata( {
-				size : arguments.validationData,
-				min  : min,
-				max  : max
+				'size' : arguments.validationData,
+				'min'  : min,
+				'max'  : max
 			} );
 		validationResult.addError( error );
 		return false;

--- a/models/validators/TypeValidator.cfc
+++ b/models/validators/TypeValidator.cfc
@@ -178,7 +178,7 @@ component accessors="true" singleton {
 				rejectedValue  : ( isSimpleValue( arguments.targetValue ) ? arguments.targetValue : "" ),
 				validationData : arguments.validationData
 			};
-			var error = validationResult.newError( argumentCollection = args ).setErrorMetadata( { type : arguments.validationData } );
+			var error = validationResult.newError( argumentCollection = args ).setErrorMetadata( { 'type' : arguments.validationData } );
 			validationResult.addError( error );
 		}
 


### PR DESCRIPTION
Just a small change to preserve key case in the errorMetadata struct. Eg

```
//Old
"USERNAME": [
    {
        "message": "The 'USERNAME' value is not in the required size range (2..20)",
        "validationData": "2..20",
        "errorMetadata": {
            "MIN": "2",
            "SIZE": "2..20",
            "MAX": "20"
        },
        "rejectedValue": "a",
        "validationType": "Size",
        "field": "USERNAME"
    }
],

//New
"USERNAME": [
    {
        "message": "The 'USERNAME' value is not in the required size range (2..20)",
        "validationData": "2..20",
        "errorMetadata": {
            "min": "2",
            "size": "2..20",
            "max": "20"
        },
        "rejectedValue": "a",
        "validationType": "Size",
        "field": "USERNAME"
    }
],
```
