### PR TITLE
Unique validators

### DIFF
--- a/models/validators/UniqueValidator.cfc
+++ b/models/validators/UniqueValidator.cfc
@@ -4,18 +4,22 @@
  * ---
  * This validator validates if a value is unique in a database
  */
-component accessors="true" singleton {
+component
+	extends  ="BaseValidator"
+	accessors="true"
+	singleton
+{
 
 	property name="name";
-	property name="res" 				inject="model:resourceService@cbi18n";
-    property name="moduleService" inject="coldbox:moduleService";
-    property name="wirebox" inject="wirebox";
+	property name="res"           inject="model:resourceService@cbi18n";
+	property name="moduleService" inject="coldbox:moduleService";
+	property name="wirebox"       inject="wirebox";
 
 	/**
 	 * Constructor
 	 */
-	QUniqueValidator function init() {
-		variables.name = "QUniqueValidator";
+	UniqueValidator function init(){
+		variables.name = "UniqueValidator";
 		return this;
 	}
 
@@ -33,60 +37,42 @@ component accessors="true" singleton {
 		required string field,
 		any targetValue,
 		any validationData
-	) {
+	){
+		// uniqueness detection for non orm (orm has its own validator)
+		// validationData.table (required)
+		param validationData.column      = arguments.field;
+		param validationData.keyProperty = "id";
+		param validationData.keyColumn   = validationData.keyProperty;
+		// validationData.dataSource optional
+		// validationData.isLoaded to override isLoaded detection
 
-        //check to see if cborm is loaded and if this is a cform entity
-        if ( moduleService.isModuleActive("cborm") and getMetadata(arguments.target).persistent ?: false ) {
-            // do cborm unique detection
-            var ormService=wirebox.getInstance("BaseORMService@cborm");
-            // process entity setups.
-            var entityName    = ORMService.getEntityGivenName( arguments.target );
-            var identityField = ORMService.getKey( entityName );
-            var identityValue = invoke(
-                arguments.target,
-                "get#identityField#"
-            );
-            // create criteria for uniqueness
-            var c = ORMService.newCriteria( entityName ).isEq( field, arguments.targetValue );
-            // validate with ID? then add to restrictions
-            if ( !isNull( identityValue ) ) {
-                c.ne( identityField, identityValue );
-            }
-            if ( !c.count() ) return true;
-        } else {
-            // uniqueness detection for non orm
-            // validationData.table (required)
-            param validationData.column = arguments.field;
-            param validationData.keyProperty  = "id";
-            param validationData.keyColumn    = validationData.keyProperty;
-            // validationData.dataSource optional
-            // validationData.isLoaded to override isLoaded detection
+		// return true if no data to check, type needs a data element to be checked.
+		if ( isNullOrEmpty( arguments.targetValue ) ) {
+			return true;
+		}
 
-            // return true if no data to check, type needs a data element to be checked.
-            if ( isNullOrEmpty( arguments.targetValue ) ) {
-                return true;
-            }
-
-            var sql     = "Select 1 from #validationData.table# where #validationData.column# = :name";
-            //prepare query params
-            var params  = { 
-                name : arguments.targetValue
-            };
-            // add datasource property, or use default
-            var options = arguments.validationdata.keyExists("datasource") ? { datasource: arguments.validationdata.datasource } : {}; 
-            // now get IDvalue or null if there's no ID value yet
-            var IdValue = invoke( target, "get#validationData.keyProperty#" );
-            // isLoaded: if not present detect isLoaded by valid ID which has some length
-            var isLoaded = !arguments.validationData.KeyExists("isLoaded") ?  !IsNull(idValue) && len(IdValue) : arguments.validationData.isLoaded;
-            // add datasource property, or use default
-            if ( isLoaded ) {
-                //add extra param and sql to exclude current record
-                params.id = IdValue;
-                sql &= " and #validationData.keyColumn# <> :id"
-            }
-            var result = queryExecute( sql, params, options )
-            if ( !result.recordCount ) return true;
-        }
+		var sql     = "Select 1 from #validationData.table# where #validationData.column# = :name";
+		// prepare query params
+		var params  = { name : arguments.targetValue };
+		// add datasource property, or use default
+		var options = arguments.validationdata.keyExists( "datasource" ) ? {
+			datasource : arguments.validationdata.datasource
+		} : {};
+		// now get IDvalue or null if there's no ID value yet
+		var IdValue = invoke(
+			target,
+			"get#validationData.keyProperty#"
+		);
+		// isLoaded: if not present detect isLoaded by valid ID which has some length
+		var isLoaded = !arguments.validationData.KeyExists( "isLoaded" ) ? !isNull( idValue ) && len( IdValue ) : arguments.validationData.isLoaded;
+		// add datasource property, or use default
+		if ( isLoaded ) {
+			// add extra param and sql to exclude current record
+			params.id = IdValue;
+			sql &= " and #validationData.keyColumn# <> :id"
+		}
+		var result = queryExecute( sql, params, options )
+		if ( !result.recordCount ) return true;
 
 		// construction of your validation error messages
 		var args = {
@@ -96,19 +82,12 @@ component accessors="true" singleton {
 			rejectedValue  : ( isSimpleValue( arguments.targetValue ) ? arguments.targetValue : "" ),
 			validationData : arguments.validationData
 		};
-		validationResult.addError( 
+		validationResult.addError(
 			validationResult
 				.newError( argumentCollection = args )
-				.setErrorMetadata( { QUniqueValidator : arguments.validationData } )
+				.setErrorMetadata( { UniqueValidator : arguments.validationData } )
 		);
 		return false;
-	}
-
-	/**
-	 * Get the name of the validator
-	 */
-	string function getName() {
-		return variables.name;
 	}
 
 }

--- a/models/validators/UniqueValidator.cfc
+++ b/models/validators/UniqueValidator.cfc
@@ -52,7 +52,7 @@ component accessors="true" singleton {
             if ( !isNull( identityValue ) ) {
                 c.ne( identityField, identityValue );
             }
-            if ( c.count() ) return true;
+            if ( !c.count() ) return true;
         } else {
             // uniqueness detection for non orm
             // validationData.table (required)

--- a/models/validators/UniqueValidator.cfc
+++ b/models/validators/UniqueValidator.cfc
@@ -2,27 +2,25 @@
  * Copyright since 2020 by Ortus Solutions, Corp
  * www.ortussolutions.com
  * ---
- * This validator checks the database according to validation data for field uniqueness
- * - table : The table name to seek
- * - column : The column to evaluate for uniqueness or defaults to the name of the field
+ * This validator validates if a value is unique in a database
  */
-component
-	extends  ="BaseValidator"
-	accessors="true"
-	singleton
-{
+component accessors="true" singleton {
+
+	property name="name";
+	property name="res" 				inject="model:resourceService@cbi18n";
+    property name="moduleService" inject="coldbox:moduleService";
+    property name="wirebox" inject="wirebox";
 
 	/**
 	 * Constructor
 	 */
-	UniqueValidator function init(){
-		variables.name = "Unique";
+	QUniqueValidator function init() {
+		variables.name = "QUniqueValidator";
 		return this;
 	}
 
 	/**
 	 * Will check if an incoming value validates
-	 *
 	 * @validationResult The result object of the validation
 	 * @target The target object to validate on
 	 * @field The field on the target object to validate on
@@ -30,36 +28,87 @@ component
 	 * @validationData The validation data the validator was created with
 	 */
 	boolean function validate(
-		required any validationResult,
+		required  validationResult,
 		required any target,
 		required string field,
 		any targetValue,
 		any validationData
-	){
-		// Default the target column
-		var targetColumn = ( isNull( arguments.validationData.column ) ? arguments.field : arguments.validationData.column );
-		// Query it
-		var exists       = queryExecute(
-			"SELECT 1 FROM #arguments.validationData.table# WHERE #targetColumn# = ?",
-			[ arguments.targetValue ]
-		).recordCount > 0;
+	) {
 
-		if ( !exists ) {
-			return true;
-		}
+        //check to see if cborm is loaded and if this is a cform entity
+        if ( moduleService.isModuleActive("cborm") and getMetadata(arguments.target).persistent ?: false ) {
+            // do cborm unique detection
+            var ormService=wirebox.getInstance("BaseORMService@cborm");
+            // process entity setups.
+            var entityName    = ORMService.getEntityGivenName( arguments.target );
+            var identityField = ORMService.getKey( entityName );
+            var identityValue = invoke(
+                arguments.target,
+                "get#identityField#"
+            );
+            // create criteria for uniqueness
+            var c = ORMService.newCriteria( entityName ).isEq( field, arguments.targetValue );
+            // validate with ID? then add to restrictions
+            if ( !isNull( identityValue ) ) {
+                c.ne( identityField, identityValue );
+            }
+            if ( c.count() ) return true;
+        } else {
+            // uniqueness detection for non orm
+            // validationData.table (required)
+            param validationData.column = arguments.field;
+            param validationData.keyProperty  = "id";
+            param validationData.keyColumn    = validationData.keyProperty;
+            // validationData.dataSource optional
+            // validationData.isLoaded to override isLoaded detection
 
-		validationResult.addError(
-			validationResult.newError(
-				argumentCollection = {
-					message        : "The #targetColumn# '#arguments.targetValue#' is already in use",
-					field          : arguments.field,
-					validationType : getName(),
-					validationData : arguments.validationData
-				}
-			)
+            // return true if no data to check, type needs a data element to be checked.
+            if ( isNullOrEmpty( arguments.targetValue ) ) {
+                return true;
+            }
+
+            var sql     = "Select 1 from #validationData.table# where #validationData.column# = :name";
+            //prepare query params
+            var params  = { 
+                name : arguments.targetValue
+            };
+            // add datasource property, or use default
+            var options = arguments.validationdata.keyExists("datasource") ? { datasource: arguments.validationdata.datasource } : {}; 
+            // now get IDvalue or null if there's no ID value yet
+            var IdValue = invoke( target, "get#validationData.keyProperty#" );
+            // isLoaded: if not present detect isLoaded by valid ID which has some length
+            var isLoaded = !arguments.validationData.KeyExists("isLoaded") ?  !IsNull(idValue) && len(IdValue) : arguments.validationData.isLoaded;
+            // add datasource property, or use default
+            if ( isLoaded ) {
+                //add extra param and sql to exclude current record
+                params.id = IdValue;
+                sql &= " and #validationData.keyColumn# <> :id"
+            }
+            var result = queryExecute( sql, params, options )
+            if ( !result.recordCount ) return true;
+        }
+
+		// construction of your validation error messages
+		var args = {
+			message        : "The '#arguments.field#' value '#arguments.targetValue#' is not unique",
+			field          : arguments.field,
+			validationType : getName(),
+			rejectedValue  : ( isSimpleValue( arguments.targetValue ) ? arguments.targetValue : "" ),
+			validationData : arguments.validationData
+		};
+		validationResult.addError( 
+			validationResult
+				.newError( argumentCollection = args )
+				.setErrorMetadata( { QUniqueValidator : arguments.validationData } )
 		);
-
 		return false;
+	}
+
+	/**
+	 * Get the name of the validator
+	 */
+	string function getName() {
+		return variables.name;
 	}
 
 }


### PR DESCRIPTION
We should think about ways to test the db and orm stuff.

I added the orm validation conditionally, by checking if cborm was loaded and if we had an entity.

If not, you have to configure at least a table property, and in some cases some more properties. It should work for both model and struct validation, but when using for structs you have to include the id (key) 