### PR TITLE
Date Comparisons Fail if Compare field is empty

### DIFF
--- a/models/validators/AfterOrEqualValidator.cfc
+++ b/models/validators/AfterOrEqualValidator.cfc
@@ -58,6 +58,11 @@ component
 				"get#arguments.validationData#"
 			);
 		}
+		
+		// return true if no value to compare against
+		if ( isNull( compareValue ) || isNullOrEmpty( compareValue ) ) {
+			return true;
+		}
 
 		/**
 		 * -1 if date1 is before than date2

--- a/models/validators/AfterValidator.cfc
+++ b/models/validators/AfterValidator.cfc
@@ -58,6 +58,11 @@ component
 				"get#arguments.validationData#"
 			);
 		}
+		
+		// return true if no value to compare against
+		if ( isNull( compareValue ) || isNullOrEmpty( compareValue ) ) {
+			return true;
+		}
 
 		/**
 		 * -1 if date1 is before than date2

--- a/models/validators/BeforeOrEqualValidator.cfc
+++ b/models/validators/BeforeOrEqualValidator.cfc
@@ -58,6 +58,11 @@ component
 				"get#arguments.validationData#"
 			);
 		}
+		
+		// return true if no value to compare against
+		if ( isNull( compareValue ) || isNullOrEmpty( compareValue ) ) {
+			return true;
+		}
 
 		/**
 		 * -1 if date1 is before than date2

--- a/models/validators/BeforeValidator.cfc
+++ b/models/validators/BeforeValidator.cfc
@@ -58,6 +58,11 @@ component
 				"get#arguments.validationData#"
 			);
 		}
+		
+		// return true if no value to compare against
+		if ( isNull( compareValue ) || isNullOrEmpty( compareValue ) ) {
+			return true;
+		}
 
 		/**
 		 * -1 if date1 is before than date2

--- a/models/validators/DateEqualsValidator.cfc
+++ b/models/validators/DateEqualsValidator.cfc
@@ -58,6 +58,11 @@ component
 				"get#arguments.validationData#"
 			);
 		}
+		
+		// return true if no value to compare against
+		if ( isNull( compareValue ) || isNullOrEmpty( compareValue ) ) {
+			return true;
+		}
 
 		/**
 		 * -1 if date1 is before than date2


### PR DESCRIPTION
The date comparison validators (before, beforeOrEqual, after, afterOrEqual, DateEqual) throw an error when comparing the target field to another field on the model if the comparison field is empty