### PR TITLE
Fix process result metadata replacements

### DIFF
--- a/models/result/ValidationResult.cfc
+++ b/models/result/ValidationResult.cfc
@@ -209,13 +209,17 @@ component accessors="true" {
 
 		// process result metadata replacements
 		var errorData = arguments.error.getErrorMetadata();
-		for ( var key in errorData ) {
-			arguments.message = replaceNoCase(
-				arguments.message,
-				"{#key#}",
-				errorData[ key ],
-				"all"
-			);
+
+		if ( !isNull(errorData) ) {
+			for ( var key in errorData ) {
+				arguments.message = replaceNoCase(
+					arguments.message,
+					"{#key#}",
+					errorData[ key ],
+					"all"
+				);
+			}
+	
 		}
 
 		// override message


### PR DESCRIPTION
If null support is set to true, that passage would give a "Can't cast Null value to Collection" error. 
Checking if errorData is not null before parsing it actually fixes the issue.