### PR TITLE
🐛 FIX: Correct build:docs script bugs

### DIFF
--- a/build/Build.cfc
+++ b/build/Build.cfc
@@ -130,9 +130,7 @@ component {
 			)
 			.toConsole();
 
-		// Prepare exports directory
-		variables.exportsDir = variables.artifactsDir & "/#projectName#/#arguments.version#";
-		directoryCreate( variables.exportsDir, true, true );
+		ensureExportDir( argumentCollection = arguments );
 
 		// Project Build Dir
 		variables.projectBuildDir = variables.buildDir & "/#projectName#";
@@ -200,11 +198,12 @@ component {
 		version   = "1.0.0",
 		outputDir = ".tmp/apidocs"
 	){
+		ensureExportDir( argumentCollection = arguments );
+
 		// Create project mapping
 		fileSystemUtil.createMapping( arguments.projectName, variables.cwd );
 		// Generate Docs
 		print.greenLine( "Generating API Docs, please wait..." ).toConsole();
-		directoryCreate( arguments.outputDir, true, true );
 
 		command( "docbox generate" )
 			.params(
@@ -315,4 +314,18 @@ component {
 		return ( createObject( "java", "java.lang.System" ).getProperty( "cfml.cli.exitCode" ) ?: 0 );
 	}
 
+	/**
+	 * Ensure the export directory exists at artifacts/NAME/VERSION/
+	 */
+	private function ensureExportDir(
+		required projectName,
+		version   = "1.0.0"
+	){
+		if ( structKeyExists( variables, "exportsDir" ) && directoryExists( variables.exportsDir ) ){
+			return;
+		}
+		// Prepare exports directory
+		variables.exportsDir = variables.artifactsDir & "/#projectName#/#arguments.version#";
+		directoryCreate( variables.exportsDir, true, true );
+	}
 }

--- a/test-harness/tests/Application.cfc
+++ b/test-harness/tests/Application.cfc
@@ -1,8 +1,8 @@
 ﻿/**
-* Copyright 2005-2007 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
-* www.ortussolutions.com
-* ---
-*/
+ * Copyright 2005-2007 ColdBox Framework by Luis Majano and Ortus Solutions, Corp
+ * www.ortussolutions.com
+ * ---
+ */
 component {
 
 	// UPDATE THE NAME OF THE MODULE IN TESTING BELOW
@@ -10,21 +10,21 @@ component {
 	request.MODULE_PATH = "cbvalidation";
 
 	// APPLICATION CFC PROPERTIES
-	this.name 				= "ColdBoxTestingSuite";
-	this.sessionManagement 	= true;
-	this.setClientCookies 	= true;
-	this.sessionTimeout 	= createTimeSpan( 0, 0, 15, 0 );
-	this.applicationTimeout = createTimeSpan( 0, 0, 15, 0 );
-    // Turn on/off white space management
+	this.name                 = "ColdBoxTestingSuite";
+	this.sessionManagement    = true;
+	this.setClientCookies     = true;
+	this.sessionTimeout       = createTimespan( 0, 0, 15, 0 );
+	this.applicationTimeout   = createTimespan( 0, 0, 15, 0 );
+	// Turn on/off white space management
 	this.whiteSpaceManagement = "smart";
-    this.enableNullSupport = shouldEnableFullNullSupport();
+	this.enableNullSupport    = shouldEnableFullNullSupport();
 
 	// Create testing mapping
 	this.mappings[ "/tests" ] = getDirectoryFromPath( getCurrentTemplatePath() );
 
 	// The application root
-	rootPath                 = reReplaceNoCase( this.mappings[ "/tests" ], "tests(\\|/)", "" );
-	this.mappings[ "/root" ] = rootPath;
+	rootPath                   = reReplaceNoCase( this.mappings[ "/tests" ], "tests(\\|/)", "" );
+	this.mappings[ "/root" ]   = rootPath;
 	this.mappings[ "/cbi18n" ] = rootPath & "modules/cbi18n";
 
 	// The module root path
@@ -39,9 +39,9 @@ component {
 	// request start
 	public boolean function onRequestStart( String targetPage ){
 		// Set a high timeout for long running tests
-		setting requestTimeout="9999";
+		setting requestTimeout   ="9999";
 		// New ColdBox Virtual Application Starter
-		request.coldBoxVirtualApp = new coldbox.system.testing.VirtualApp( appMapping = "/root" );
+		request.coldBoxVirtualApp= new coldbox.system.testing.VirtualApp( appMapping = "/root" );
 
 		// If hitting the runner or specs, prep our virtual app
 		if ( getBaseTemplatePath().replace( expandPath( "/tests" ), "" ).reFindNoCase( "(runner|specs)" ) ) {
@@ -49,8 +49,8 @@ component {
 		}
 
 		// ORM Reload for fresh results
-		if( structKeyExists( url, "fwreinit" ) ){
-			if( structKeyExists( server, "lucee" ) ){
+		if ( structKeyExists( url, "fwreinit" ) ) {
+			if ( structKeyExists( server, "lucee" ) ) {
 				pagePoolClear();
 			}
 			// ormReload();
@@ -60,14 +60,14 @@ component {
 		return true;
 	}
 
-	public void function onRequestEnd( required targetPage ) {
+	public void function onRequestEnd( required targetPage ){
 		request.coldBoxVirtualApp.shutdown();
 	}
 
-    private boolean function shouldEnableFullNullSupport() {
-        var system = createObject( "java", "java.lang.System" );
-        var value = system.getEnv( "FULL_NULL" );
-        return isNull( value ) ? false : !!value;
-    }
+	private boolean function shouldEnableFullNullSupport(){
+		var system = createObject( "java", "java.lang.System" );
+		var value  = system.getEnv( "FULL_NULL" );
+		return isNull( value ) ? false : !!value;
+	}
 
 }


### PR DESCRIPTION
This PR corrects a few bugs in the build:docs box script:

An error when running box run-script build:docs because variables.exportsDir doesn't exist.
The directoryCreate( outputDir ) is worse than useless, since DocBox creates this dir for you, and this code creates the wrong directory anyway! (it creates .tmp/apidocs/ inside the build/ directory, which is not where it should be.)