### PR TITLE
🐛 FIX: Update GHA to avoid deprecated syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           java-version: "11"
 
       - name: Cache CommandBox Dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         if: ${{ true }}
         with:
           path: ~/.CommandBox/artifacts

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: taiki-e/create-gh-release-action@v1.5.0
+      - uses: taiki-e/create-gh-release-action@v1.6.1
         with:
           # Produced by the build/Build.cfc
           changelog: changelog.md

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
           box testbox run --verbose outputFile=test-harness/tests/results/test-results outputFormats=json,antjunit
 
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: test-harness/tests/results/**/*.xml


### PR DESCRIPTION
The [create-gh-release-action](https://github.com/taiki-e/create-gh-release-action) needs updating to avoid GitHub's deprecated set-output syntax.

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/