### PR TITLE
Issue #73 Discrete and Inlist Validations throw error if data element value is not simple value

### DIFF
--- a/models/validators/DiscreteValidator.cfc
+++ b/models/validators/DiscreteValidator.cfc
@@ -55,6 +55,25 @@ component extends="BaseValidator" accessors="true" singleton {
 			return true;
 		}
 
+		// check data element value and return error if it is not simple value.
+		if ( !isSimpleValue( arguments.targetValue ) ) {
+            var args = {
+                message        : "The '#arguments.field#' value is not a Simple value",
+                field          : arguments.field,
+                validationType : getName(),
+                rejectedValue  : ( isSimpleValue( arguments.targetValue ) ? arguments.targetValue : "" ),
+                validationData : arguments.validationData
+            };
+            var error = validationResult
+                .newError( argumentCollection = args )
+                .setErrorMetadata( {
+                    "operation"      : operation,
+                    "operationValue" : operationValue
+                } );
+            validationResult.addError( error );
+          return false;
+        }
+
 		var r = false;
 		if ( !isNull( arguments.targetValue ) ) {
 			switch ( operation ) {

--- a/models/validators/InListValidator.cfc
+++ b/models/validators/InListValidator.cfc
@@ -36,6 +36,24 @@ component extends="BaseValidator" accessors="true" singleton {
 			return true;
 		}
 
+		// check data element value and return error if it is not simple value.
+		if ( !isSimpleValue( arguments.targetValue ) ) {
+            var args = {
+                message        : "The '#arguments.field#' value is not a Simple value",
+                field          : arguments.field,
+                validationType : getName(),
+                rejectedValue  : ( isSimpleValue( arguments.targetValue ) ? arguments.targetValue : "" ),
+                validationData : arguments.validationData
+            };
+            var error = validationResult
+                .newError( argumentCollection = args )
+                .setErrorMetadata( {
+                    "inlist" : arguments.validationData
+                } );
+            validationResult.addError( error );
+          return false;
+        }
+
 		// Now check
 		if ( listFindNoCase( arguments.validationData, arguments.targetValue ) ) {
 			return true;

--- a/test-harness/tests/specs/validators/DiscreteValidatorTest.cfc
+++ b/test-harness/tests/specs/validators/DiscreteValidatorTest.cfc
@@ -47,6 +47,10 @@ component extends="coldbox.system.testing.BaseModelTest" model="cbvalidation.mod
 		assertEquals( false, r );
 		r = model.validate( result, this, "test", 4, "gte:4" );
 		assertEquals( true, r );
+
+		// Validation check - if simple value
+		r = model.validate( result, this, "test1", [], "gte:1" );
+		assertEquals( false, r );
 	}
 
 }

--- a/test-harness/tests/specs/validators/DiscreteValidatorTest.cfc
+++ b/test-harness/tests/specs/validators/DiscreteValidatorTest.cfc
@@ -49,7 +49,7 @@ component extends="coldbox.system.testing.BaseModelTest" model="cbvalidation.mod
 		assertEquals( true, r );
 
 		// Validation check - if simple value
-		r = model.validate( result, this, "test1", [], "gte:1" );
+		r = model.validate( result, this, "test", [], "gte:1" );
 		assertEquals( false, r );
 	}
 

--- a/test-harness/tests/specs/validators/InListValidatorTest.cfc
+++ b/test-harness/tests/specs/validators/InListValidatorTest.cfc
@@ -32,6 +32,16 @@ component extends="coldbox.system.testing.BaseModelTest" model="cbvalidation.mod
 			"luis,joe,alexia,vero"
 		);
 		assertEquals( true, r );
+
+		// not simple value
+		r = model.validate(
+			result,
+			this,
+			"test",
+			[],
+			"luis,joe,alexia,vero"
+		);
+		assertEquals( false, r );
 	}
 
 	function getLuis(){


### PR DESCRIPTION
# Description

Discrete Validations throw error if data element value is not simple value.

Steps to replicate issue :
Discrete validation:
```
var validationResult = validate(
target = {
// passing userid as an empty array
"userid": []
},
constraints = {
"userid": { "required": true, "type": "integer","discrete": "gte:1" }
}
);
```
InList validation:
```
var validationResult = validate(
    target = {
        "userid": []
    },
    constraints = {
        "userid": { "required": true, "type": "integer","inList": "1,2,3,4,5" }
    }
);
```
## Issues

Fixes #73 Discrete and inList validations throw error if data element value is not simple value

## Type of change

- [ ] Bug Fix

## Checklist

- [ ] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
