### PR TITLE
[BugFix] Only perform type evaluation if target value is not null or empty string

### DIFF
--- a/models/validators/TypeValidator.cfc
+++ b/models/validators/TypeValidator.cfc
@@ -44,7 +44,7 @@ component extends="BaseValidator" accessors="true" singleton {
 		}
 
 		// return true if no data to check, type needs a data element to be checked.
-		if ( isNull( arguments.targetValue ) ) {
+		if ( isNull( arguments.targetValue ) || isNullOrEmpty( arguments.targetValue ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
See my comment on https://github.com/coldbox-modules/cbvalidation/issues/45
