### PR TITLE
[Breaking Change] Update `RequiredIf` Validator to Accept UDF/Closure and Update `UDF` Validator for Consistency When Handling Null/Empty Values

### DIFF
--- a/models/validators/MethodValidator.cfc
+++ b/models/validators/MethodValidator.cfc
@@ -38,11 +38,6 @@ component extends="BaseValidator" accessors="true" singleton {
 			return true;
 		}
 
-		// return true if no data to check, type needs a data element to be checked.
-		if ( isNull( arguments.targetValue ) || isNullOrEmpty( arguments.targetValue ) ) {
-			return true;
-		}
-
 		// Validate via method
 		if (
 			invoke(

--- a/models/validators/RequiredIfValidator.cfc
+++ b/models/validators/RequiredIfValidator.cfc
@@ -37,8 +37,8 @@ component
 		any validationData,
 		struct rules
 	){
-		var isRequired = true;
-        var errorMetadata = {};
+		var isRequired    = true;
+		var errorMetadata = {};
 
 		// If you passed in simple data, simply check that the target field has a value
 		if ( isSimpleValue( arguments.validationData ) && len( arguments.validationData ) ) {
@@ -61,22 +61,19 @@ component
 				.reduce( function( result, key, value ){
 					return ( arguments.value && arguments.result );
 				}, true );
-        // If passed a UDF/closure
-        } else if ( 
-            isCustomFunction( arguments.validationData ) || 
-            isClosure( arguments.validationData )
-        ) {
-            
-            // Validate against the UDF/closure
-            var isRequired = arguments.validationData(
-                isNull( arguments.targetValue ) ? javacast( "null", "" ) : arguments.targetValue,
-                arguments.target,
-                errorMetadata
-            );
-
-        } else {
-            
-            validationResult.addError(
+			// If passed a UDF/closure
+		} else if (
+			isCustomFunction( arguments.validationData ) ||
+			isClosure( arguments.validationData )
+		) {
+			// Validate against the UDF/closure
+			var isRequired = arguments.validationData(
+				isNull( arguments.targetValue ) ? javacast( "null", "" ) : arguments.targetValue,
+				arguments.target,
+				errorMetadata
+			);
+		} else {
+			validationResult.addError(
 				validationResult.newError(
 					message        = "The target for RequiredIf must be a simple field name or a struct of field to target value pairs.",
 					field          = arguments.field,
@@ -109,9 +106,9 @@ component
 			validationData : arguments.validationData
 		};
 
-		validationResult.addError( 
-            validationResult.newError( argumentCollection = args ).setErrorMetadata( errorMetadata ) 
-        );
+		validationResult.addError(
+			validationResult.newError( argumentCollection = args ).setErrorMetadata( errorMetadata )
+		);
 		return false;
 	}
 

--- a/models/validators/RequiredIfValidator.cfc
+++ b/models/validators/RequiredIfValidator.cfc
@@ -38,6 +38,7 @@ component
 		struct rules
 	){
 		var isRequired = true;
+        var errorMetadata = {};
 
 		// If you passed in simple data, simply check that the target field has a value
 		if ( isSimpleValue( arguments.validationData ) && len( arguments.validationData ) ) {
@@ -60,13 +61,27 @@ component
 				.reduce( function( result, key, value ){
 					return ( arguments.value && arguments.result );
 				}, true );
-		} else {
-			validationResult.addError(
+        // If passed a UDF/closure
+        } else if ( 
+            isCustomFunction( arguments.validationData ) || 
+            isClosure( arguments.validationData )
+        ) {
+            
+            // Validate against the UDF/closure
+            var isRequired = arguments.validationData(
+                isNull( arguments.targetValue ) ? javacast( "null", "" ) : arguments.targetValue,
+                arguments.target,
+                errorMetadata
+            );
+
+        } else {
+            
+            validationResult.addError(
 				validationResult.newError(
 					message        = "The target for RequiredIf must be a simple field name or a struct of field to target value pairs.",
 					field          = arguments.field,
 					validationType = getName(),
-					rejectedValue  = arguments.validationData,
+					rejectedValue  = isSimpleValue( arguments.validationData ) ? arguments.validationData : "",
 					validationData = arguments.validationData
 				)
 			);
@@ -94,7 +109,9 @@ component
 			validationData : arguments.validationData
 		};
 
-		validationResult.addError( validationResult.newError( argumentCollection = args ) );
+		validationResult.addError( 
+            validationResult.newError( argumentCollection = args ).setErrorMetadata( errorMetadata ) 
+        );
 		return false;
 	}
 

--- a/models/validators/UDFValidator.cfc
+++ b/models/validators/UDFValidator.cfc
@@ -34,9 +34,14 @@ component extends="BaseValidator" accessors="true" singleton {
 	){
 		var errorMetadata = {};
 
+        // return true if no data to check, type needs a data element to be checked.
+		if ( isNull( arguments.targetValue ) || isNullOrEmpty( arguments.targetValue ) ) {
+			return true;
+		}
+
 		// Validate against the UDF/closure
 		var passed = arguments.validationData(
-			isNull( arguments.targetValue ) ? javacast( "null", "" ) : arguments.targetValue,
+			arguments.targetValue,
 			arguments.target,
 			errorMetadata
 		);

--- a/models/validators/UDFValidator.cfc
+++ b/models/validators/UDFValidator.cfc
@@ -34,7 +34,7 @@ component extends="BaseValidator" accessors="true" singleton {
 	){
 		var errorMetadata = {};
 
-        // return true if no data to check, type needs a data element to be checked.
+		// return true if no data to check, type needs a data element to be checked.
 		if ( isNull( arguments.targetValue ) || isNullOrEmpty( arguments.targetValue ) ) {
 			return true;
 		}

--- a/test-harness/tests/specs/validators/RequiredIfValidatorTest.cfc
+++ b/test-harness/tests/specs/validators/RequiredIfValidatorTest.cfc
@@ -106,17 +106,78 @@ component extends="coldbox.system.testing.BaseModelTest" model="cbvalidation.mod
 
 				expect( model.validate( result, mock, "testField", "", "name" ) ).toBeFalse();
 
-				// expect(
-				//     model.validate(
-				//         result,
-				//         mock,
-				//         "testField",
-				//         "",
-				//         "missing"
-				//     )
-				// ).toBeTrue();
+				expect(
+                    model.validate(
+                        result,
+                        mock,
+                        "testField",
+                        "",
+                        "missing"
+                    )
+				).toBeTrue();
+			} );
+            it( "can accept a closure as validationData", function(){
+				var mock = createStub()
+					.$( "getName", "luis" )
+					.$( "getRole", "admin" )
+					.$( "getMissing", javacast( "null", "" ) );
+				var result = createMock( "cbvalidation.models.result.ValidationResult" ).init();
+
+				expect( 
+                    model.validate( 
+                        result, 
+                        mock, 
+                        "testField", 
+                        "", 
+                        isRequired1 
+                    ) ).toBeFalse();
+
+				expect(
+                    model.validate(
+                        result,
+                        mock,
+                        "testField",
+                        "",
+                        isRequired2
+                    )
+				).toBeTrue();
+			} );
+            it( "can use custom error metadata", function(){
+				var mock = createStub()
+					.$( "getName", "luis" )
+					.$( "getRole", "admin" )
+					.$( "getMissing", javacast( "null", "" ) );
+				var result = createMock( "cbvalidation.models.result.ValidationResult" ).init();
+
+				expect( 
+                    model.validate( 
+                        result, 
+                        mock, 
+                        "testField", 
+                        "", 
+                        isRequired3 
+                    ) ).toBeFalse();
+
+                var errorMetadata = result.getErrors()[ 1 ].getErrorMetadata();
+
+                expect( errorMetaData ).toHaveKey( "customMessage" );
+                expect( errorMetaData.customMessage ).toBe( "This is custom data" );
+                
 			} );
 		} );
+	}
+
+    private function isRequired1( value, target, errorMetadata ){
+		return true;
+	}
+
+    private function isRequired2( value, target, errorMetadata ){
+		return false;
+	}
+
+    private function isRequired3( value, target, errorMetadata ){
+		arguments.errorMetadata[ "customMessage" ] = "This is custom data";
+        return true;
 	}
 
 }

--- a/test-harness/tests/specs/validators/RequiredIfValidatorTest.cfc
+++ b/test-harness/tests/specs/validators/RequiredIfValidatorTest.cfc
@@ -106,78 +106,47 @@ component extends="coldbox.system.testing.BaseModelTest" model="cbvalidation.mod
 
 				expect( model.validate( result, mock, "testField", "", "name" ) ).toBeFalse();
 
-				expect(
-                    model.validate(
-                        result,
-                        mock,
-                        "testField",
-                        "",
-                        "missing"
-                    )
-				).toBeTrue();
+				expect( model.validate( result, mock, "testField", "", "missing" ) ).toBeTrue();
 			} );
-            it( "can accept a closure as validationData", function(){
+			it( "can accept a closure as validationData", function(){
 				var mock = createStub()
 					.$( "getName", "luis" )
 					.$( "getRole", "admin" )
 					.$( "getMissing", javacast( "null", "" ) );
 				var result = createMock( "cbvalidation.models.result.ValidationResult" ).init();
 
-				expect( 
-                    model.validate( 
-                        result, 
-                        mock, 
-                        "testField", 
-                        "", 
-                        isRequired1 
-                    ) ).toBeFalse();
+				expect( model.validate( result, mock, "testField", "", isRequired1 ) ).toBeFalse();
 
-				expect(
-                    model.validate(
-                        result,
-                        mock,
-                        "testField",
-                        "",
-                        isRequired2
-                    )
-				).toBeTrue();
+				expect( model.validate( result, mock, "testField", "", isRequired2 ) ).toBeTrue();
 			} );
-            it( "can use custom error metadata", function(){
+			it( "can use custom error metadata", function(){
 				var mock = createStub()
 					.$( "getName", "luis" )
 					.$( "getRole", "admin" )
 					.$( "getMissing", javacast( "null", "" ) );
 				var result = createMock( "cbvalidation.models.result.ValidationResult" ).init();
 
-				expect( 
-                    model.validate( 
-                        result, 
-                        mock, 
-                        "testField", 
-                        "", 
-                        isRequired3 
-                    ) ).toBeFalse();
+				expect( model.validate( result, mock, "testField", "", isRequired3 ) ).toBeFalse();
 
-                var errorMetadata = result.getErrors()[ 1 ].getErrorMetadata();
+				var errorMetadata = result.getErrors()[ 1 ].getErrorMetadata();
 
-                expect( errorMetaData ).toHaveKey( "customMessage" );
-                expect( errorMetaData.customMessage ).toBe( "This is custom data" );
-                
+				expect( errorMetaData ).toHaveKey( "customMessage" );
+				expect( errorMetaData.customMessage ).toBe( "This is custom data" );
 			} );
 		} );
 	}
 
-    private function isRequired1( value, target, errorMetadata ){
+	private function isRequired1( value, target, errorMetadata ){
 		return true;
 	}
 
-    private function isRequired2( value, target, errorMetadata ){
+	private function isRequired2( value, target, errorMetadata ){
 		return false;
 	}
 
-    private function isRequired3( value, target, errorMetadata ){
+	private function isRequired3( value, target, errorMetadata ){
 		arguments.errorMetadata[ "customMessage" ] = "This is custom data";
-        return true;
+		return true;
 	}
 
 }

--- a/test-harness/tests/specs/validators/UDFValidatorTest.cfc
+++ b/test-harness/tests/specs/validators/UDFValidatorTest.cfc
@@ -34,7 +34,7 @@ component extends="coldbox.system.testing.BaseModelTest" model="cbvalidation.mod
 			javacast( "null", "" ),
 			variables.validate3
 		);
-		assertEquals( false, r );
+		assertEquals( true, r );
 	}
 
 	private function validate( value, target ){


### PR DESCRIPTION
This change adds additional functionality to the `RequiredIf` validator.  Now, you can pass a UDF/closure to the validator to dynamically evaluate whether the field is required or not.  The UDF/closure should return `true` if the field is required and `false` if not.

Example: 
```
myField = {
 // myField is required if today is Monday.
 requiredIf = function( value, target, errorMetadata ) {
        return dayOfWeekAsString( dayOfWeek( now() ) ) == "Monday";
 }
}
```

The `UDF` validator was also updated for consistency (see https://github.com/ortus-docs/cbvalidation-docs/issues/13) and will treat null/empty values as valid.  Developers who want to dynamically determine whether a field should be required will need to switch to using `RequiredIf`.   This is a BREAKING change and should be reserved for the next major version of CBValidation.

