### PR TITLE
Update RequiredIf Validator to Accept UDF/Closure

### DIFF
--- a/models/validators/RequiredIfValidator.cfc
+++ b/models/validators/RequiredIfValidator.cfc
@@ -38,6 +38,7 @@ component
 		struct rules
 	){
 		var isRequired = true;
+        var errorMetadata = {};
 
 		// If you passed in simple data, simply check that the target field has a value
 		if ( isSimpleValue( arguments.validationData ) && len( arguments.validationData ) ) {
@@ -60,13 +61,27 @@ component
 				.reduce( function( result, key, value ){
 					return ( arguments.value && arguments.result );
 				}, true );
-		} else {
-			validationResult.addError(
+        // If passed a UDF/closure
+        } else if ( 
+            isCustomFunction( arguments.validationData ) || 
+            isClosure( arguments.validationData )
+        ) {
+            
+            // Validate against the UDF/closure
+            var isRequired = arguments.validationData(
+                isNull( arguments.targetValue ) ? javacast( "null", "" ) : arguments.targetValue,
+                arguments.target,
+                errorMetadata
+            );
+
+        } else {
+            
+            validationResult.addError(
 				validationResult.newError(
 					message        = "The target for RequiredIf must be a simple field name or a struct of field to target value pairs.",
 					field          = arguments.field,
 					validationType = getName(),
-					rejectedValue  = arguments.validationData,
+					rejectedValue  = isSimpleValue( arguments.validationData ) ? arguments.validationData : "",
 					validationData = arguments.validationData
 				)
 			);
@@ -94,7 +109,9 @@ component
 			validationData : arguments.validationData
 		};
 
-		validationResult.addError( validationResult.newError( argumentCollection = args ) );
+		validationResult.addError( 
+            validationResult.newError( argumentCollection = args ).setErrorMetadata( errorMetadata ) 
+        );
 		return false;
 	}
 

--- a/test-harness/tests/specs/validators/RequiredIfValidatorTest.cfc
+++ b/test-harness/tests/specs/validators/RequiredIfValidatorTest.cfc
@@ -106,17 +106,78 @@ component extends="coldbox.system.testing.BaseModelTest" model="cbvalidation.mod
 
 				expect( model.validate( result, mock, "testField", "", "name" ) ).toBeFalse();
 
-				// expect(
-				//     model.validate(
-				//         result,
-				//         mock,
-				//         "testField",
-				//         "",
-				//         "missing"
-				//     )
-				// ).toBeTrue();
+				expect(
+                    model.validate(
+                        result,
+                        mock,
+                        "testField",
+                        "",
+                        "missing"
+                    )
+				).toBeTrue();
+			} );
+            it( "can accept a closure as validationData", function(){
+				var mock = createStub()
+					.$( "getName", "luis" )
+					.$( "getRole", "admin" )
+					.$( "getMissing", javacast( "null", "" ) );
+				var result = createMock( "cbvalidation.models.result.ValidationResult" ).init();
+
+				expect( 
+                    model.validate( 
+                        result, 
+                        mock, 
+                        "testField", 
+                        "", 
+                        isRequired1 
+                    ) ).toBeFalse();
+
+				expect(
+                    model.validate(
+                        result,
+                        mock,
+                        "testField",
+                        "",
+                        isRequired2
+                    )
+				).toBeTrue();
+			} );
+            it( "can use custom error metadata", function(){
+				var mock = createStub()
+					.$( "getName", "luis" )
+					.$( "getRole", "admin" )
+					.$( "getMissing", javacast( "null", "" ) );
+				var result = createMock( "cbvalidation.models.result.ValidationResult" ).init();
+
+				expect( 
+                    model.validate( 
+                        result, 
+                        mock, 
+                        "testField", 
+                        "", 
+                        isRequired3 
+                    ) ).toBeFalse();
+
+                var errorMetadata = result.getErrors()[ 1 ].getErrorMetadata();
+
+                expect( errorMetaData ).toHaveKey( "customMessage" );
+                expect( errorMetaData.customMessage ).toBe( "This is custom data" );
+                
 			} );
 		} );
+	}
+
+    private function isRequired1( value, target, errorMetadata ){
+		return true;
+	}
+
+    private function isRequired2( value, target, errorMetadata ){
+		return false;
+	}
+
+    private function isRequired3( value, target, errorMetadata ){
+		arguments.errorMetadata[ "customMessage" ] = "This is custom data";
+        return true;
 	}
 
 }


### PR DESCRIPTION
This change adds additional functionality to the `RequiredIf` validator.  Now, you can pass a UDF/closure to the validator to dynamically evaluate whether the field is required or not.  The UDF/closure should return `true` if the field is required and `false` if not.

Example: 
```
// constraints
myField = {
    // myField is required if today is Monday.
    requiredIf = function( value, target, errorMetadata ) {
        return dayOfWeekAsString( dayOfWeek( now() ) ) == "Monday";
    }
}
```
