### PR TITLE
[Breaking Change] Update UDF validator to treat null/empty values as valid

### DIFF
--- a/models/validators/MethodValidator.cfc
+++ b/models/validators/MethodValidator.cfc
@@ -38,11 +38,6 @@ component extends="BaseValidator" accessors="true" singleton {
 			return true;
 		}
 
-		// return true if no data to check, type needs a data element to be checked.
-		if ( isNull( arguments.targetValue ) || isNullOrEmpty( arguments.targetValue ) ) {
-			return true;
-		}
-
 		// Validate via method
 		if (
 			invoke(

--- a/models/validators/UDFValidator.cfc
+++ b/models/validators/UDFValidator.cfc
@@ -34,9 +34,14 @@ component extends="BaseValidator" accessors="true" singleton {
 	){
 		var errorMetadata = {};
 
+        // return true if no data to check, type needs a data element to be checked.
+		if ( isNull( arguments.targetValue ) || isNullOrEmpty( arguments.targetValue ) ) {
+			return true;
+		}
+
 		// Validate against the UDF/closure
 		var passed = arguments.validationData(
-			isNull( arguments.targetValue ) ? javacast( "null", "" ) : arguments.targetValue,
+			arguments.targetValue,
 			arguments.target,
 			errorMetadata
 		);

--- a/test-harness/tests/specs/ValidationIntegrations.cfc
+++ b/test-harness/tests/specs/ValidationIntegrations.cfc
@@ -159,7 +159,8 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 						params = {
 							username : "luis",
 							email    : "lmajano@ortussolutions.com",
-							password : "luis"
+							password : "luis",
+                            status   : 4 // should not validate
 						},
 						method = "post"
 					);

--- a/test-harness/tests/specs/validators/UDFValidatorTest.cfc
+++ b/test-harness/tests/specs/validators/UDFValidatorTest.cfc
@@ -34,7 +34,7 @@ component extends="coldbox.system.testing.BaseModelTest" model="cbvalidation.mod
 			javacast( "null", "" ),
 			variables.validate3
 		);
-		assertEquals( false, r );
+		assertEquals( true, r );
 	}
 
 	private function validate( value, target ){


### PR DESCRIPTION
Updated for consistency (see https://github.com/ortus-docs/cbvalidation-docs/issues/13) and will treat null/empty values as valid.  Developers who want to dynamically determine whether a field should be required will need to switch to using the`RequiredIf` validator.   

Warning: This PR should be viewed as a breaking change and reserved for the next major version of CBValidation.